### PR TITLE
Replacing main function in evaluate_repo as entrypoint for cocoa package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ The goals of this codebase is to provide a quick and easy way to review code and
 ```pip install cocoa```
 
 To install the package from the local files, run the following command from the root of the repository:
-```python3 -m pip install .```
+```bash
+python3 -m pip install .
+```
 
 ### cocoa
 
@@ -29,7 +31,14 @@ cocoa /path/to/repo
 
 As a python script: 
 ```bash
-python3 /src/cocoa/evaluate_repo.py /path/to/repo
+python3 src/cocoa/evaluate_repo.py /path/to/repo
+```
+
+As a Python module:
+```python
+from cocoa.evaluate_repo import evaluate_repo
+
+evaluate_repo('/path/to/repo', False)
 ```
 
 A few important notes:

--- a/src/cocoa/evaluate_repo.py
+++ b/src/cocoa/evaluate_repo.py
@@ -120,7 +120,7 @@ def evaluate_repo(dir_path, lint_flag):
     return 0
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="COCOA CLI")
 
     parser.add_argument("repo", help="Path to a repository root directory")
@@ -132,3 +132,7 @@ if __name__ == "__main__":
     lint_flag = args.lint
 
     evaluate_repo(dir_path, lint_flag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Previous changes removed the main() function from evaluate_repo.py. This is needed in pyproject.toml as the entrypoint for the cocoa package. These changes replace that main() function.