### PR TITLE
Make black consistent with pre-commit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ profile = black
 default_section = THIRDPARTY
 skip = venv/
 skip_glob = **/migrations/*.py
+line_length = 80

--- a/src/cocoa/linting.py
+++ b/src/cocoa/linting.py
@@ -117,7 +117,7 @@ def black_python_file(file_path):
         formatted_content = black.format_file_contents(
             content,
             fast=False,
-            mode=black.FileMode(),
+            mode=black.FileMode(line_length=80),
         )
 
         # Compare original and formatted content


### PR DESCRIPTION
Makes black and isort consistent with pre-commit via line_length. 