### PR TITLE
Reformat cocoa to run based of [tool.cocoa] block in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,40 @@ Via command line:
 cocoa /path/to/repo
 ```
 
-#### Options
+#### Configuration
+
+Cocoa can be configured via command-line arguments or through a `pyproject.toml` file in the root of the repository being analyzed. Command-line arguments always override settings in `pyproject.toml`.
+
+**Command-Line Options:**
+
+- `repo`: (Required) Path to the repository directory or a Git URL.
+- `--verbose`: Print all linting results instead of truncating (default: `False`).
+- `--branch <branch-name>`: Specify the branch to evaluate (default: `main`).
+- `--branchinfo`: Report detailed information about remote branches (default: `False`).
+- `--date <YYYY-MM-DD>`: Only analyze files committed on or after this date (defualt: `None`).
+- `--max-cells-per-notebook`: Maximum number of cells allowed in a Jupyter Notebook (default: `10`).
+- `--max-lines-per-cell`: Maximum number of lines allowed in a Jupyter Notebook Cell (default: `15`).
+- `--max-functions-per-notebook`: Maximum number of function definitions per notebook (default: `0`).
+
+**`pyproject.toml` Options:**
+
+Create a `[tool.cocoa]` section in your `pyproject.toml` file. Each option for the command line is an option in the pyproject.toml. Example file:
+
+```toml
+[tool.cocoa]
+# General settings
+verbose = false
+date = "YYYY-MM-DD"  # Optional: same as --date
+branchinfo = false
+branch = "main"
+
+# Notebook specific limits
+max-cells-per-notebook = 10
+max-lines-per-cell = 15
+max-functions-per-notebook = 0
+```
+
+**Example Usage:**
 
 Results are truncated by default. To print all results, use the verbose option:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "ipython",
     "termcolor",
     "requests",
-    "ruff"
+    "ruff",
+    'tomli; python_version < "3.11"',
 ]
 
 [project.scripts]

--- a/src/cocoa/config.py
+++ b/src/cocoa/config.py
@@ -1,0 +1,52 @@
+"""Loads configuration for Cocoa from pyproject.toml."""
+
+import sys
+from pathlib import Path
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
+DEFAULT_CONFIG = {
+    "max_cells_per_notebook": 10,
+    "max_lines_per_cell": 15,
+    "max_functions_per_notebook": 0,
+    "ruff_select": "ANN,B,C4,D,I,N801,N804,N805,PD,PLR2004,PTH,W,S,UP,YTT",
+    "ruff_ignore": "D415,ANN002,ANN003,ANN101,ANN102,B905",
+}
+
+
+def load_config(repo_path: Path | str) -> dict:
+    """Loads configuration from pyproject.toml, using defaults if necessary.
+
+    Args:
+        repo_path: The path to the repository to load configuration from.
+
+    Returns:
+        A dictionary containing the configuration settings.
+    """
+    repo_path = Path(repo_path)
+    pyproject_path = repo_path / "pyproject.toml"
+    config = DEFAULT_CONFIG.copy()
+
+    if pyproject_path.exists():
+        try:
+            with pyproject_path.open("rb") as f:
+                pyproject_data = tomllib.load(f)
+            cocoa_config = pyproject_data.get("tool", {}).get("cocoa", {})
+
+            # Merge user config with defaults, converting keys
+            for key, value in cocoa_config.items():
+                # Convert kebab-case keys from pyproject.toml to snake_case
+                snake_case_key = key.replace("-", "_")
+                if snake_case_key in config:
+                    config[snake_case_key] = value
+                else:
+                    print(f"Warning: Unknown configuration key '{key}' in [tool.cocoa]")
+        except tomllib.TOMLDecodeError as e:
+            print(f"Error parsing {pyproject_path}: {e}")
+        except Exception as e:
+            print(f"Error loading configuration from {pyproject_path}: {e}")
+
+    return config

--- a/src/cocoa/config.py
+++ b/src/cocoa/config.py
@@ -8,12 +8,54 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
+# Config names mapped to argparse.ConfigParser.add_argument()
+# keyword arguments dictionaries
 DEFAULT_CONFIG = {
-    "max_cells_per_notebook": 10,
-    "max_lines_per_cell": 15,
-    "max_functions_per_notebook": 0,
-    "ruff_select": "ANN,B,C4,D,I,N801,N804,N805,PD,PLR2004,PTH,W,S,UP,YTT",
-    "ruff_ignore": "D415,ANN002,ANN003,ANN101,ANN102,B905",
+    "max_cells_per_notebook": {
+        "help": "Maximum number of cells allowed in a Jupyter Notebook",
+        "type": int,
+        "default": 10,
+    },
+    "max_lines_per_cell": {
+        "help": "Maximum number of lines allowed in a Jupyter Notebook Cell",
+        "type": int,
+        "default": 15,
+    },
+    "max_functions_per_notebook": {
+        "help": "Maximum number of function definitions per notebook",
+        "type": int,
+        "default": 0,
+    },
+    "ruff_select": {
+        "help": "Ruff linter select options",
+        "type": str,
+        "default": "ANN,B,C4,D,I,N801,N804,N805,PD,PLR2004,PTH,W,S,UP,YTT",
+    },
+    "ruff_ignore": {
+        "help": "Ruff linter ignore options",
+        "type": str,
+        "default": "D415,ANN002,ANN003,ANN101,ANN102,B905",
+    },
+    "verbose": {
+        "help": "Print all results",
+        "default": False,
+        "action": "store_true",
+    },
+    "start_date": {
+        "help": "Start date in YYYY-MM-DD format to filter files by commit date",
+        "type": str,
+        "default": None,
+    },
+    "branchinfo": {
+        "help": "Report branch information",
+        "default": False,
+        "action": "store_true",
+    },
+    "branch_name": {
+        "help": "Branch name to evaluate",
+        "type": str,
+        "default": "main",
+    },
 }
 
 
@@ -28,7 +70,7 @@ def load_config(repo_path: Path | str) -> dict:
     """
     repo_path = Path(repo_path)
     pyproject_path = repo_path / "pyproject.toml"
-    config = DEFAULT_CONFIG.copy()
+    config = {key: value["default"] for key, value in DEFAULT_CONFIG.items()}
 
     if pyproject_path.exists():
         try:

--- a/src/cocoa/constants.py
+++ b/src/cocoa/constants.py
@@ -1,12 +1,7 @@
 """Constants used throughout the repository or default values"""
 
-MAX_CELLS_PER_NOTEBOOK = 10
-MAX_LINES_PER_CELL = 15
-MAX_FUNCTIONS_PER_NOTEBOOK = 0
 PREAMBLE_TEXT = (
     "Visit https://github.com/dsi-clinic/the-clinic/blob/main/"
     "rubrics/final-technical-cleanup.md for more information "
     "on the criteria used here."
 )
-RUFF_SELECT = "ANN,B,C4,D,I,N801,N804,N805,PD,PLR2004,PTH,W,S,UP,YTT"
-RUFF_IGNORE = "D415,ANN002,ANN003,ANN101,ANN102,B905"

--- a/src/cocoa/evaluate_repo.py
+++ b/src/cocoa/evaluate_repo.py
@@ -7,12 +7,8 @@ from pathlib import Path
 
 from termcolor import cprint
 
-from cocoa.constants import (
-    MAX_CELLS_PER_NOTEBOOK,
-    MAX_FUNCTIONS_PER_NOTEBOOK,
-    MAX_LINES_PER_CELL,
-    PREAMBLE_TEXT,
-)
+from cocoa.config import load_config
+from cocoa.constants import PREAMBLE_TEXT
 from cocoa.linting import (
     code_contains_subprocess,
     is_code_in_functions_or_main,
@@ -33,7 +29,7 @@ from cocoa.repo import (
 
 
 def walk_and_process(
-    dir_path: str, start_date: str = None, verbose: bool = False
+    dir_path: str, config: dict, start_date: str = None, verbose: bool = False
 ) -> None:
     """Walk through directory and process all python and jupyter notebook files."""
     paths_to_flag = ["__pycache__", "DS_Store", "ipynb_checkpoints"]
@@ -56,43 +52,47 @@ def walk_and_process(
         if Path(file_path).exists():
             if file_path.endswith(".ipynb") or file_path.endswith(".py"):
                 if file_path.endswith(".ipynb"):
-                    analyze_notebook(file_path, verbose)
+                    analyze_notebook(file_path, config, verbose)
                 elif file_path.endswith(".py"):
-                    analyze_python_file(file_path, verbose)
+                    analyze_python_file(file_path, config, verbose)
 
 
-def analyze_notebook(file_path: str, verbose: bool) -> None:
+def analyze_notebook(file_path: str, config: dict, verbose: bool) -> None:
     """Analyze a notebook"""
     num_cells, num_lines, num_functions, max_lines_in_cell = process_notebook(file_path)
 
-    ruff_results = run_ruff_and_capture_output(file_path)
+    ruff_results = run_ruff_and_capture_output(
+        file_path, config["ruff_select"], config["ruff_ignore"]
+    )
     ruff_results = process_ruff_results(ruff_results)
 
     if (
         len(ruff_results) > 0
-        or num_cells > MAX_CELLS_PER_NOTEBOOK
-        or max_lines_in_cell > MAX_LINES_PER_CELL
-        or num_functions > MAX_FUNCTIONS_PER_NOTEBOOK
+        or num_cells > config["max_cells_per_notebook"]
+        or max_lines_in_cell > config["max_lines_per_cell"]
+        or num_functions > config["max_functions_per_notebook"]
     ):
         print(f"Analyzing {file_path}:")
         if len(ruff_results) > 0:
             print_results("ruff", ruff_results, verbose=verbose)
 
-        if num_cells > MAX_CELLS_PER_NOTEBOOK:
+        if num_cells > config["max_cells_per_notebook"]:
             print(f"\tMax number of cells exceeded: {num_cells}")
-        if max_lines_in_cell > MAX_LINES_PER_CELL:
+        if max_lines_in_cell > config["max_lines_per_cell"]:
             print(f"\tMax number of lines per cell exceeded: {max_lines_in_cell}")
-        if num_functions > MAX_FUNCTIONS_PER_NOTEBOOK:
+        if num_functions > config["max_functions_per_notebook"]:
             print(f"\tFunction definitions detected: {num_functions}")
 
         print("-" * 80)
 
 
-def analyze_python_file(file_path: str, verbose: bool) -> None:
+def analyze_python_file(file_path: str, config: dict, verbose: bool) -> None:
     """Analyze a Python file"""
     contains_subprocess = code_contains_subprocess(file_path)
     code_in_functions = is_code_in_functions_or_main(file_path)
-    ruff_results = run_ruff_and_capture_output(file_path)
+    ruff_results = run_ruff_and_capture_output(
+        file_path, config["ruff_select"], config["ruff_ignore"]
+    )
     ruff_results = process_ruff_results(ruff_results)
 
     if contains_subprocess or len(ruff_results) > 0 or not code_in_functions:
@@ -140,24 +140,31 @@ def evaluate_repo(
             print(f"Error: {path_or_url} is not a Git repository.")
             exit(1)
 
+        repo_path_obj = Path(path_or_url)
+        config = load_config(repo_path_obj)
         switch_branches(path_or_url, branch_name)
 
-        check_branch_names(path_or_url)
+        check_branch_names(repo_path_obj)
         if branchinfo:
-            get_remote_branches_info(path_or_url)
+            get_remote_branches_info(repo_path_obj)
 
         walk_and_process(
-            path_or_url,
+            repo_path_obj,
+            config=config,
             start_date=start_date,
             verbose=verbose,
         )
 
     elif is_git_remote_repo(path_or_url):
         repo_path = clone_repo(path_or_url)
+        repo_path_obj = Path(repo_path)
+        config = load_config(repo_path_obj)
         evaluate_repo(
             repo_path,
             start_date=start_date,
             verbose=verbose,
+            branchinfo=branchinfo,
+            branch_name=branch_name,
         )
         shutil.rmtree(repo_path)
     else:

--- a/src/cocoa/evaluate_repo.py
+++ b/src/cocoa/evaluate_repo.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from termcolor import cprint
 
-from cocoa.config import load_config
+from cocoa.config import DEFAULT_CONFIG, load_config
 from cocoa.constants import PREAMBLE_TEXT
 from cocoa.linting import (
     code_contains_subprocess,
@@ -28,9 +28,7 @@ from cocoa.repo import (
 )
 
 
-def walk_and_process(
-    dir_path: str, config: dict, start_date: str = None, verbose: bool = False
-) -> None:
+def walk_and_process(dir_path: str, config: dict, verbose: bool = False) -> None:
     """Walk through directory and process all python and jupyter notebook files."""
     paths_to_flag = ["__pycache__", "DS_Store", "ipynb_checkpoints"]
     cprint(
@@ -38,8 +36,8 @@ def walk_and_process(
         color="green",
     )
 
-    if start_date:
-        files_to_process = files_after_date(dir_path, start_date)
+    if config["start_date"]:
+        files_to_process = files_after_date(dir_path, config["start_date"])
     else:
         files_to_process = [
             str(Path(root, f))
@@ -128,10 +126,7 @@ def print_results(tool_name: str, results: list, verbose: bool = False) -> None:
 
 def evaluate_repo(
     path_or_url: str,
-    start_date: str = None,
-    verbose: bool = False,
-    branchinfo: bool = False,
-    branch_name: str = "main",
+    config: dict,
 ) -> None:
     """Runs the repo evaluation."""
     cprint(PREAMBLE_TEXT, color="green")
@@ -142,17 +137,15 @@ def evaluate_repo(
 
         repo_path_obj = Path(path_or_url)
         config = load_config(repo_path_obj)
-        switch_branches(path_or_url, branch_name)
+        switch_branches(path_or_url, config["branch_name"])
 
         check_branch_names(repo_path_obj)
-        if branchinfo:
+        if config["branchinfo"]:
             get_remote_branches_info(repo_path_obj)
 
         walk_and_process(
             repo_path_obj,
             config=config,
-            start_date=start_date,
-            verbose=verbose,
         )
 
     elif is_git_remote_repo(path_or_url):
@@ -161,10 +154,7 @@ def evaluate_repo(
         config = load_config(repo_path_obj)
         evaluate_repo(
             repo_path,
-            start_date=start_date,
-            verbose=verbose,
-            branchinfo=branchinfo,
-            branch_name=branch_name,
+            config=config,
         )
         shutil.rmtree(repo_path)
     else:
@@ -178,31 +168,27 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="COCOA CLI")
 
     parser.add_argument("repo", help="Path to a repository root directory")
-    parser.add_argument("--verbose", help="Print all results", action="store_true")
-    parser.add_argument(
-        "--date",
-        default=None,
-        help="Start date in YYYY-MM-DD format to filter files by commit date",
-        type=str,
-    )
-    parser.add_argument(
-        "--branchinfo", help="Report branch information", action="store_true"
-    )
-    parser.add_argument(
-        "--branch",
-        default="main",
-        help="Specify which branch to evaluate",
-        type=str,
-    )
+
+    # arguments added to parser based on DEFAULT_CONFIG in config.py
+    for setting_name, setting_info in DEFAULT_CONFIG.items():
+        # remove defaults. Since CLI overrides pyproject.toml, which overrides defaults,
+        # we don't want to set defaults here.
+        setting_info_no_default = {
+            k: v for k, v in setting_info.items() if k != "default"
+        }
+        parser.add_argument(
+            f"--{setting_name.replace('_', '-')}",
+            **setting_info_no_default,
+        )
     args = parser.parse_args()
+    config = load_config(args.repo)
+    for arg_name, arg_value in vars(args).items():
+        if arg_value is not None:
+            config[arg_name.replace("-", "_")] = arg_value
 
     dir_path = args.repo
-    start_date = args.date
-    verbose = args.verbose
-    branchinfo = args.branchinfo
-    branch = args.branch
-
-    evaluate_repo(dir_path, start_date, verbose, branchinfo, branch)
+    print(config)
+    evaluate_repo(dir_path, config)
 
 
 if __name__ == "__main__":

--- a/src/cocoa/linting.py
+++ b/src/cocoa/linting.py
@@ -5,10 +5,8 @@ import re
 import subprocess
 from pathlib import Path
 
-from cocoa.constants import RUFF_IGNORE, RUFF_SELECT
 
-
-def run_ruff_and_capture_output(path: str) -> str:
+def run_ruff_and_capture_output(path: str, ruff_select: str, ruff_ignore: str) -> str:
     """Runs ruff as subprocess and return output as a string."""
     try:
         # Run the ruff command
@@ -18,9 +16,9 @@ def run_ruff_and_capture_output(path: str) -> str:
                 "check",
                 path,
                 "--extend-select",
-                RUFF_SELECT,
+                ruff_select,
                 "--ignore",
-                RUFF_IGNORE,
+                ruff_ignore,
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
Uses config.py to define defaults, can be overridden per repository it is run on

For each configuration, when running cocoa precedence goes CLI args > pyproject.toml > defaults

When developing, to add new options, add them to the defaults dictionary in config.py. There might be a slightly cleaner way to do this, but this method works as far as I can tell. 